### PR TITLE
Add `satmap-` prefix to CSS layers

### DIFF
--- a/lib/main.css
+++ b/lib/main.css
@@ -1,3 +1,3 @@
-@layer theme, base, components, utilities;
-@import "tailwindcss/theme.css" layer(theme) prefix(satmap);
-@import "tailwindcss/utilities.css" layer(utilities) prefix(satmap);
+@layer satmap-theme, satmap-utilities;
+@import "tailwindcss/theme.css" layer(satmap-theme) prefix(satmap);
+@import "tailwindcss/utilities.css" layer(satmap-utilities) prefix(satmap);


### PR DESCRIPTION
The CSS layers named `theme` and `utilities` might conflict with a user’s Tailwind CSS, so this PR adds a `satmap-` prefix to the layer names.