### PR TITLE
Use npm trusted publishing

### DIFF
--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -28,6 +28,3 @@ jobs:
       - run: pnpm build
 
       - run: pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Background

The v0.5.0 release publish retried with an updated npm token, but npm still rejected the publish with an OTP requirement. The package has now been configured for npm Trusted Publishing, so the release workflow should rely on GitHub Actions OIDC instead of a long-lived npm token.

pnpm publish is kept because pnpm delegates the publish operation to npm, and the workflow already runs on a Node/npm version that supports Trusted Publishing.

## Changes

- Remove the token-based publish environment from the npm release workflow.
- Let npm Trusted Publishing provide authentication and provenance through the existing id-token: write permission.

## Validation

- Parsed .github/workflows/npm.yaml as YAML.
- Ran git diff --check for the workflow change.