### PR TITLE
Release v0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-sat-map",
   "description": "React components for visualizing real-time satellite locations on a map",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Background

This patch release publishes the MapLibre GL v6 compatibility update and stops bundling the `maplibre-gl` peer dependency into react-sat-map. Applications will now consistently use their own peer-installed MapLibre GL instance.

## Changes

- Bump the package version to 0.5.1.